### PR TITLE
feat: Add reportCarriers route

### DIFF
--- a/cmd/server/routes/carriersRouter.go
+++ b/cmd/server/routes/carriersRouter.go
@@ -17,6 +17,6 @@ func carriersRouter(superRouter *gin.RouterGroup, dbConnection *sql.DB) {
 	pr := superRouter.Group("/carriers")
 	{
 		pr.POST("/", carrierController.Create())
-		pr.GET("/reportLocalities", carrierController.ReportCarriers())
 	}
+	superRouter.GET("/localities/reportCarriers", carrierController.ReportCarriers())
 }

--- a/cmd/server/routes/carriersRouter.go
+++ b/cmd/server/routes/carriersRouter.go
@@ -1,0 +1,22 @@
+package routes
+
+import (
+	"database/sql"
+
+	"github.com/gin-gonic/gin"
+	"github.com/marcoglnd/mercado-fresco-packmain/internal/carriers/controller"
+	repository "github.com/marcoglnd/mercado-fresco-packmain/internal/carriers/repository/mariadb"
+	"github.com/marcoglnd/mercado-fresco-packmain/internal/carriers/service"
+)
+
+func carriersRouter(superRouter *gin.RouterGroup, dbConnection *sql.DB) {
+	repository := repository.NewCarrierRepository(dbConnection)
+	service := service.NewCarrierService(repository)
+	carrierController := controller.NewCarrierController(service)
+
+	pr := superRouter.Group("/carriers")
+	{
+		pr.POST("/", carrierController.Create())
+		pr.GET("/reportLocalities", carrierController.ReportCarriers())
+	}
+}

--- a/cmd/server/routes/index.go
+++ b/cmd/server/routes/index.go
@@ -13,4 +13,5 @@ func AddRoutes(superRouter *gin.RouterGroup, dbConnection *sql.DB) {
 	sectionsRouter(superRouter)
 	warehousesRouter(superRouter, dbConnection)
 	sellersRouter(superRouter)
+	carriersRouter(superRouter, dbConnection)
 }

--- a/cmd/server/routes/warehousesRouter.go
+++ b/cmd/server/routes/warehousesRouter.go
@@ -2,7 +2,6 @@ package routes
 
 import (
 	"database/sql"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/marcoglnd/mercado-fresco-packmain/internal/warehouses/controller"
@@ -17,11 +16,6 @@ func warehousesRouter(superRouter *gin.RouterGroup, dbConnection *sql.DB) {
 
 	pr := superRouter.Group("/warehouses")
 	{
-		pr.GET("/debug", func(ctx *gin.Context) {
-			ctx.JSON(http.StatusTeapot, gin.H{
-				"debug": "is running",
-			})
-		})
 		pr.POST("/", warehouseController.Create())
 		pr.GET("/", warehouseController.GetAll())
 		pr.GET("/:id", warehouseController.GetById())

--- a/internal/carriers/controller/carrier_controller.go
+++ b/internal/carriers/controller/carrier_controller.go
@@ -66,3 +66,44 @@ func (cc *CarrierController) Create() gin.HandlerFunc {
 		)
 	}
 }
+
+// @Summary Report Carriers
+// @Tags Carriers
+// @Description Get quantity of carriers by locality id
+// @Accept json
+// @Produce json
+// @Param id query int true "locality ID"
+// @Router /reportCarriers [get]
+func (cc *CarrierController) ReportCarriers() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		var reportCarriersInput struct {
+			Id int64 `form:"id"`
+		}
+		if err := ctx.ShouldBindQuery(&reportCarriersInput); err != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		var reports *[]domain.CarrierReport
+		if reportCarriersInput.Id == 0 {
+			allReports, err := cc.service.GetAllCarriersReport(ctx)
+			if err != nil {
+				ctx.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+				return
+			}
+			reports = allReports
+		} else {
+			customReport, err := cc.service.GetCarriersReportById(
+				ctx,
+				reportCarriersInput.Id,
+			)
+			if err != nil {
+				ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			}
+			reports = &[]domain.CarrierReport{
+				*customReport,
+			}
+		}
+		ctx.JSON(http.StatusOK, gin.H{"data": reports})
+	}
+}

--- a/internal/carriers/controller/carrier_controller_test.go
+++ b/internal/carriers/controller/carrier_controller_test.go
@@ -112,3 +112,98 @@ func TestCreateFail(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusUnprocessableEntity, rr.Code)
 }
+
+func TestReportCarriersOk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	serviceMock := mock.NewMockCarrierService(ctrl)
+	controller := controller.NewCarrierController(serviceMock)
+
+	serviceMock.EXPECT().GetAllCarriersReport(gomock.Any()).Return(&[]domain.CarrierReport{}, nil)
+
+	rr := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(rr)
+
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+
+	engine.GET("/", controller.ReportCarriers())
+	engine.ServeHTTP(rr, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestReportCarriersFailValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	serviceMock := mock.NewMockCarrierService(ctrl)
+	controller := controller.NewCarrierController(serviceMock)
+
+	rr := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(rr)
+
+	req, err := http.NewRequest(http.MethodGet, "/?id=notint", nil)
+
+	engine.GET("/", controller.ReportCarriers())
+	engine.ServeHTTP(rr, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestReportCarriersFailGetAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	serviceMock := mock.NewMockCarrierService(ctrl)
+	controller := controller.NewCarrierController(serviceMock)
+
+	serviceMock.EXPECT().GetAllCarriersReport(gomock.Any()).Return(nil, errors.New("some error"))
+
+	rr := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(rr)
+
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+
+	engine.GET("/", controller.ReportCarriers())
+	engine.ServeHTTP(rr, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, rr.Code)
+}
+
+func TestReportCarriersByIdOk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	serviceMock := mock.NewMockCarrierService(ctrl)
+	controller := controller.NewCarrierController(serviceMock)
+
+	serviceMock.EXPECT().GetCarriersReportById(gomock.Any(), int64(1)).Return(&domain.CarrierReport{}, nil)
+
+	rr := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(rr)
+
+	req, err := http.NewRequest(http.MethodGet, "/?id=1", nil)
+
+	engine.GET("/", controller.ReportCarriers())
+	engine.ServeHTTP(rr, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestReportCarriersByIdFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	serviceMock := mock.NewMockCarrierService(ctrl)
+	controller := controller.NewCarrierController(serviceMock)
+
+	serviceMock.EXPECT().GetCarriersReportById(
+		gomock.Any(), int64(1),
+	).Return(nil, errors.New("some error"))
+
+	rr := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(rr)
+
+	req, err := http.NewRequest(http.MethodGet, "/?id=1", nil)
+
+	engine.GET("/", controller.ReportCarriers())
+	engine.ServeHTTP(rr, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/internal/carriers/domain/domain.go
+++ b/internal/carriers/domain/domain.go
@@ -9,6 +9,8 @@ type CarrierRepository interface {
 	FindById(ctx context.Context, id int64) (*Carrier, error)
 	FindByCid(ctx context.Context, cid string) (*Carrier, error)
 	GetAll(ctx context.Context) (*[]Carrier, error)
+	GetAllCarriersReport(ctx context.Context) (*[]CarrierReport, error)
+	GetCarriersReportById(ctx context.Context, id int64) (*CarrierReport, error)
 }
 
 type CarrierService interface {
@@ -16,4 +18,6 @@ type CarrierService interface {
 	FindById(ctx context.Context, id int64) (*Carrier, error)
 	FindByCid(ctx context.Context, cid string) (*Carrier, error)
 	IsCidAvailable(ctx context.Context, cid string) error
+	GetAllCarriersReport(ctx context.Context) (*[]CarrierReport, error)
+	GetCarriersReportById(ctx context.Context, id int64) (*CarrierReport, error)
 }

--- a/internal/carriers/domain/model.go
+++ b/internal/carriers/domain/model.go
@@ -8,3 +8,9 @@ type Carrier struct {
 	Telephone   string `json:"telephone" binding:"required"`
 	LocalityId  int64  `json:"locality_id" binding:"required"`
 }
+
+type CarrierReport struct {
+	LocalityId    int64  `json:"locality_id"`
+	LocalityName  string `json:"locality_name"`
+	CarriersCount int64  `json:"carriers_count"`
+}

--- a/internal/carriers/mocks/domain.go
+++ b/internal/carriers/mocks/domain.go
@@ -95,6 +95,36 @@ func (mr *MockCarrierRepositoryMockRecorder) GetAll(ctx interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockCarrierRepository)(nil).GetAll), ctx)
 }
 
+// GetAllCarriersReport mocks base method.
+func (m *MockCarrierRepository) GetAllCarriersReport(ctx context.Context) (*[]domain.CarrierReport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllCarriersReport", ctx)
+	ret0, _ := ret[0].(*[]domain.CarrierReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllCarriersReport indicates an expected call of GetAllCarriersReport.
+func (mr *MockCarrierRepositoryMockRecorder) GetAllCarriersReport(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllCarriersReport", reflect.TypeOf((*MockCarrierRepository)(nil).GetAllCarriersReport), ctx)
+}
+
+// GetCarriersReportById mocks base method.
+func (m *MockCarrierRepository) GetCarriersReportById(ctx context.Context, id int64) (*domain.CarrierReport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCarriersReportById", ctx, id)
+	ret0, _ := ret[0].(*domain.CarrierReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCarriersReportById indicates an expected call of GetCarriersReportById.
+func (mr *MockCarrierRepositoryMockRecorder) GetCarriersReportById(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCarriersReportById", reflect.TypeOf((*MockCarrierRepository)(nil).GetCarriersReportById), ctx, id)
+}
+
 // MockCarrierService is a mock of CarrierService interface.
 type MockCarrierService struct {
 	ctrl     *gomock.Controller
@@ -161,6 +191,36 @@ func (m *MockCarrierService) FindById(ctx context.Context, id int64) (*domain.Ca
 func (mr *MockCarrierServiceMockRecorder) FindById(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindById", reflect.TypeOf((*MockCarrierService)(nil).FindById), ctx, id)
+}
+
+// GetAllCarriersReport mocks base method.
+func (m *MockCarrierService) GetAllCarriersReport(ctx context.Context) (*[]domain.CarrierReport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllCarriersReport", ctx)
+	ret0, _ := ret[0].(*[]domain.CarrierReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllCarriersReport indicates an expected call of GetAllCarriersReport.
+func (mr *MockCarrierServiceMockRecorder) GetAllCarriersReport(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllCarriersReport", reflect.TypeOf((*MockCarrierService)(nil).GetAllCarriersReport), ctx)
+}
+
+// GetCarriersReportById mocks base method.
+func (m *MockCarrierService) GetCarriersReportById(ctx context.Context, id int64) (*domain.CarrierReport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCarriersReportById", ctx, id)
+	ret0, _ := ret[0].(*domain.CarrierReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCarriersReportById indicates an expected call of GetCarriersReportById.
+func (mr *MockCarrierServiceMockRecorder) GetCarriersReportById(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCarriersReportById", reflect.TypeOf((*MockCarrierService)(nil).GetCarriersReportById), ctx, id)
 }
 
 // IsCidAvailable mocks base method.

--- a/internal/carriers/repository/mariadb/carrier_repository.go
+++ b/internal/carriers/repository/mariadb/carrier_repository.go
@@ -128,3 +128,54 @@ func (r *carrierRepository) GetAll(
 
 	return &carriers, nil
 }
+
+func (r *carrierRepository) GetAllCarriersReport(
+	ctx context.Context,
+) (*[]domain.CarrierReport, error) {
+	reports := []domain.CarrierReport{}
+
+	rows, err := r.db.QueryContext(ctx, sqlCarriersCountAll)
+	if err != nil {
+		return &reports, err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var report domain.CarrierReport
+
+		if err := rows.Scan(
+			&report.LocalityId,
+			&report.LocalityName,
+			&report.CarriersCount,
+		); err != nil {
+			return &reports, err
+		}
+
+		reports = append(reports, report)
+	}
+
+	return &reports, nil
+}
+
+func (r *carrierRepository) GetCarriersReportById(
+	ctx context.Context,
+	id int64,
+) (*domain.CarrierReport, error) {
+	row := r.db.QueryRowContext(
+		ctx, sqlCarriersCountById, id,
+	)
+
+	foundReport := &domain.CarrierReport{}
+	err := row.Scan(
+		&foundReport.LocalityId,
+		&foundReport.LocalityName,
+		&foundReport.CarriersCount,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return foundReport, nil
+}

--- a/internal/carriers/repository/mariadb/carrier_repository_test.go
+++ b/internal/carriers/repository/mariadb/carrier_repository_test.go
@@ -300,3 +300,129 @@ func TestGetAll(t *testing.T) {
 		assert.NotNil(t, cas)
 	})
 }
+
+func TestGetAllReports(t *testing.T) {
+	reportFake := utils.CreateRandomCarrierReport()
+
+	t.Run("Must find carriers report", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer db.Close()
+
+		fakeRows := sqlmock.NewRows(
+			[]string{
+				"id",
+				"locality_name",
+				"carriers_count",
+			},
+		).AddRow(
+			reportFake.LocalityId,
+			reportFake.LocalityName,
+			reportFake.CarriersCount,
+		).AddRow(
+			reportFake.LocalityId+1,
+			reportFake.LocalityName,
+			reportFake.CarriersCount,
+		)
+
+		mock.ExpectQuery(regexp.QuoteMeta(sqlCarriersCountAll)).WillReturnRows(fakeRows)
+
+		carriersRepo := NewCarrierRepository(db)
+
+		rep, err := carriersRepo.GetAllCarriersReport(context.TODO())
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(*rep))
+	})
+
+	t.Run("Must fail finding carriers report", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(sqlCarriersCountAll)).WillReturnError(sql.ErrConnDone)
+
+		carriersRepo := NewCarrierRepository(db)
+
+		_, err = carriersRepo.GetAllCarriersReport(context.TODO())
+		assert.Error(t, err)
+	})
+
+	t.Run("Must return some carrier report and fail some queries", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer db.Close()
+
+		fakeRows := sqlmock.NewRows(
+			[]string{
+				"id",
+				"locality_name",
+				"carriers_count",
+			},
+		).AddRow(
+			-1,
+			reportFake.LocalityName,
+			reportFake.CarriersCount,
+		).AddRow(
+			nil,
+			reportFake.LocalityName,
+			reportFake.CarriersCount,
+		).RowError(2, errors.New("row error"))
+
+		mock.ExpectQuery(regexp.QuoteMeta(sqlCarriersCountAll)).WillReturnRows(fakeRows)
+
+		carriersRepo := NewCarrierRepository(db)
+
+		rep, err := carriersRepo.GetAllCarriersReport(context.TODO())
+		assert.Error(t, err)
+		assert.NotNil(t, rep)
+	})
+}
+
+func TestGetAllReportsById(t *testing.T) {
+	reportFake := utils.CreateRandomCarrierReport()
+
+	t.Run("Must find carrier report", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer db.Close()
+
+		fakeRows := sqlmock.NewRows(
+			[]string{
+				"id",
+				"locality_name",
+				"carriers_count",
+			},
+		).AddRow(
+			reportFake.LocalityId,
+			reportFake.LocalityName,
+			reportFake.CarriersCount,
+		)
+
+		mock.ExpectQuery(regexp.QuoteMeta(sqlCarriersCountById)).
+			WithArgs(
+				reportFake.LocalityId,
+			).WillReturnRows(fakeRows)
+
+		carriersRepo := NewCarrierRepository(db)
+
+		ca, err := carriersRepo.GetCarriersReportById(context.TODO(), reportFake.LocalityId)
+		assert.NoError(t, err)
+		assert.Equal(t, reportFake.CarriersCount, ca.CarriersCount)
+	})
+
+	t.Run("Must fail getting a report", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(sqlCarriersCountById)).
+			WithArgs(
+				reportFake.LocalityId,
+			).WillReturnError(errors.New("fail"))
+
+		carriersRepo := NewCarrierRepository(db)
+
+		_, err = carriersRepo.GetCarriersReportById(context.TODO(), reportFake.LocalityId)
+		assert.Error(t, err)
+	})
+}

--- a/internal/carriers/repository/mariadb/sql_queries.go
+++ b/internal/carriers/repository/mariadb/sql_queries.go
@@ -18,14 +18,31 @@ const (
 	) 
 	VALUES (?, ?, ?, ?, 1)`
 
-	sqlCarriersCount = `
+	sqlCarriersCountAll = `
 	SELECT 
+		l.id,
+		l.locality_name,
 		COUNT(c.locality_id) AS carriers_count
 	FROM 
 		localities l
 	LEFT JOIN
         carriers c
-	ON  c.locality_id = l.id
+	ON 	c.locality_id = l.id
+    GROUP BY
+        l.id
+	`
+
+	sqlCarriersCountById = `
+	SELECT 
+		l.id,
+		l.locality_name,
+		COUNT(c.locality_id) AS carriers_count
+	FROM 
+		localities l
+	LEFT JOIN
+        carriers c
+	ON 	c.locality_id = l.id
+	WHERE l.id = ?
     GROUP BY
         l.id
 	`

--- a/internal/carriers/repository/mariadb/sql_queries.go
+++ b/internal/carriers/repository/mariadb/sql_queries.go
@@ -16,7 +16,7 @@ const (
 		telephone, 
 		locality_id
 	) 
-	VALUES (?, ?, ?, ?, 1)`
+	VALUES (?, ?, ?, ?, ?)`
 
 	sqlCarriersCountAll = `
 	SELECT 

--- a/internal/carriers/service/carrier_service.go
+++ b/internal/carriers/service/carrier_service.go
@@ -64,3 +64,28 @@ func (s *carrierService) FindByCid(ctx context.Context, cid string) (*domain.Car
 
 	return foundCarrier, nil
 }
+
+func (s *carrierService) GetAllCarriersReport(
+	ctx context.Context,
+) (*[]domain.CarrierReport, error) {
+	carriersReport, err := s.repository.GetAllCarriersReport(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return carriersReport, nil
+}
+
+func (s *carrierService) GetCarriersReportById(
+	ctx context.Context,
+	id int64,
+) (*domain.CarrierReport, error) {
+	carrierReport, err := s.repository.GetCarriersReportById(ctx, id)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return carrierReport, nil
+}

--- a/internal/carriers/service/carrier_service_test.go
+++ b/internal/carriers/service/carrier_service_test.go
@@ -56,3 +56,141 @@ func TestCreateConflict(t *testing.T) {
 	assert.Nil(t, carrier)
 	assert.NotNil(t, err)
 }
+
+func TestCreateConflictFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	carrierFake := utils.CreateRandomCarrier()
+	repositoryMock.EXPECT().FindByCid(ctx, carrierFake.Cid).Return(nil, errors.New("error"))
+
+	carrier, err := service.Create(ctx, &carrierFake)
+
+	assert.Nil(t, carrier)
+	assert.NotNil(t, err)
+}
+
+func TestReportAllOk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	carriersReportFake := utils.CreateRandomListCarriersReport()
+	repositoryMock.EXPECT().GetAllCarriersReport(ctx).Return(&carriersReportFake, nil)
+
+	reports, err := service.GetAllCarriersReport(ctx)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, reports)
+	assert.Equal(t, len(*reports), len(carriersReportFake))
+}
+
+func TestReportAllFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+
+	repositoryMock.EXPECT().GetAllCarriersReport(ctx).Return(nil, errors.New("some error"))
+
+	reports, err := service.GetAllCarriersReport(ctx)
+
+	assert.Error(t, err)
+	assert.NotNil(t, err)
+	assert.Nil(t, reports)
+}
+
+func TestReportByIdOk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	carriersReportFake := utils.CreateRandomCarrierReport()
+	repositoryMock.EXPECT().GetCarriersReportById(ctx, carriersReportFake.LocalityId).Return(&carriersReportFake, nil)
+
+	reports, err := service.GetCarriersReportById(ctx, carriersReportFake.LocalityId)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, reports)
+}
+
+func TestReportByIdFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	repositoryMock.EXPECT().GetCarriersReportById(ctx, gomock.Any()).Return(nil, errors.New("repo"))
+
+	reports, err := service.GetCarriersReportById(ctx, int64(1))
+
+	assert.NotNil(t, err)
+	assert.Nil(t, reports)
+}
+
+func TestFindById(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	carrierFake := utils.CreateRandomCarrier()
+	repositoryMock.EXPECT().FindById(ctx, carrierFake.ID).Return(&carrierFake, nil)
+
+	carrier, err := service.FindById(ctx, carrierFake.ID)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, carrier)
+}
+
+func TestFindByIdFailDb(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	repositoryMock.EXPECT().FindById(ctx, gomock.Any()).Return(nil, errors.New("error"))
+
+	carrier, err := service.FindById(ctx, int64(1))
+
+	assert.NotNil(t, err)
+	assert.Nil(t, carrier)
+}
+
+func TestFindByIdFailNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	repositoryMock.EXPECT().FindById(ctx, gomock.Any()).Return(nil, nil)
+
+	carrier, err := service.FindById(ctx, int64(1))
+
+	assert.NotNil(t, err)
+	assert.Nil(t, carrier)
+}
+
+func TestFindByCid(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	carrierFake := utils.CreateRandomCarrier()
+	repositoryMock.EXPECT().FindByCid(ctx, carrierFake.Cid).Return(&carrierFake, nil)
+
+	carrier, err := service.FindByCid(ctx, carrierFake.Cid)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, carrier)
+}
+
+func TestFindByCidFailDb(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repositoryMock := mock.NewMockCarrierRepository(ctrl)
+	service := service.NewCarrierService(repositoryMock)
+	ctx := context.TODO()
+	repositoryMock.EXPECT().FindByCid(ctx, gomock.Any()).Return(nil, errors.New("error"))
+
+	carrier, err := service.FindByCid(ctx, "")
+
+	assert.NotNil(t, err)
+	assert.Nil(t, carrier)
+}

--- a/internal/warehouses/repository/mariadb/sql_queries.go
+++ b/internal/warehouses/repository/mariadb/sql_queries.go
@@ -17,7 +17,7 @@ const (
 		minimum_temperature, 
 		locality_id
 	) 
-	VALUES (?, ?, ?, ?, ?, 1)`
+	VALUES (?, ?, ?, ?, ?, ?)`
 
 	sqlUpdate = `
 	UPDATE warehouses SET

--- a/internal/warehouses/repository/mariadb/warehouse_repository.go
+++ b/internal/warehouses/repository/mariadb/warehouse_repository.go
@@ -28,6 +28,7 @@ func (r *warehouseRepository) Create(
 		&warehouse.WarehouseCode,
 		&warehouse.MinimumCapacity,
 		&warehouse.MinimumTemperature,
+		&warehouse.LocalityId,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/warehouses/repository/mariadb/warehouse_repository_test.go
+++ b/internal/warehouses/repository/mariadb/warehouse_repository_test.go
@@ -27,6 +27,7 @@ func TestCreate(t *testing.T) {
 				warehouseFake.WarehouseCode,
 				warehouseFake.MinimumCapacity,
 				warehouseFake.MinimumTemperature,
+				warehouseFake.LocalityId,
 			).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		warehousesRepo := NewWarehouseRepository(db)
@@ -43,6 +44,7 @@ func TestCreate(t *testing.T) {
 
 		mock.ExpectExec(regexp.QuoteMeta(sqlStore)).
 			WithArgs(
+				0,
 				0,
 				0,
 				0,
@@ -68,6 +70,7 @@ func TestCreate(t *testing.T) {
 				warehouseFake.WarehouseCode,
 				warehouseFake.MinimumCapacity,
 				warehouseFake.MinimumTemperature,
+				warehouseFake.LocalityId,
 			).WillReturnResult(sqlmock.NewErrorResult(errors.New("fail")))
 
 		warehousesRepo := NewWarehouseRepository(db)

--- a/utils/random_carrier.go
+++ b/utils/random_carrier.go
@@ -14,6 +14,15 @@ func CreateRandomCarrier() domain.Carrier {
 	return carrier
 }
 
+func CreateRandomCarrierReport() domain.CarrierReport {
+	carrierReport := domain.CarrierReport{
+		LocalityId:    0,
+		LocalityName:  RandomString(6),
+		CarriersCount: RandomInt(1, 100),
+	}
+	return carrierReport
+}
+
 func CreateRandomListCarriers() []domain.Carrier {
 	var listOfCarriers []domain.Carrier
 	for i := 1; i <= 5; i++ {
@@ -22,4 +31,14 @@ func CreateRandomListCarriers() []domain.Carrier {
 		listOfCarriers = append(listOfCarriers, carrier)
 	}
 	return listOfCarriers
+}
+
+func CreateRandomListCarriersReport() []domain.CarrierReport {
+	var listOfCarriersReport []domain.CarrierReport
+	for i := 1; i <= 5; i++ {
+		report := CreateRandomCarrierReport()
+		report.LocalityId = int64(i)
+		listOfCarriersReport = append(listOfCarriersReport, report)
+	}
+	return listOfCarriersReport
 }


### PR DESCRIPTION
This PR adds `/reportCarriers` route to fill the requirement of Sprint III.
Also, 100% test coverage has been reached for Carrier route.